### PR TITLE
Initial version of direct exchange backend validation

### DIFF
--- a/django/.env.dev
+++ b/django/.env.dev
@@ -1,6 +1,8 @@
 DEBUG=0
 SECRET_KEY=foo
 
+JWT_KEY=change_in_production
+
 MYSQL_DATABASE=tts
 MYSQL_PASSWORD=root
 MYSQL_USER=root

--- a/django/entrypoint.sh
+++ b/django/entrypoint.sh
@@ -1,33 +1,35 @@
-#!bin/sh 
+#!bin/sh
 
-# WARNING: The script will not work if formated with CRLF. 
+# WARNING: The script will not work if formated with CRLF.
 
-# Configure the shell behaviour. 
+# Configure the shell behaviour.
 set -e
-if [[ ${DEBUG} == 1 ]]
-then set -x
-fi 
+if [[ ${DEBUG} == 1 ]]; then
+	set -x
+fi
 
 # Get parameters.
-database_host="$1"    # The database host and should be provided the container name. 
+database_host="$1" # The database host and should be provided the container name.
 shift
 cmd="$@"
 
-# Waits for mysql initialization. 
+# Waits for mysql initialization.
 until mysql -h "$database_host" -u ${MYSQL_USER} -p${MYSQL_PASSWORD} ${MYSQL_DATABASE} -e 'select 1'; do
-  >&2 echo "MySQL is unavailable - sleeping"
-  sleep 4
+	echo >&2 "MySQL is unavailable - sleeping"
+	sleep 4
 done
->&2 echo "Mysql is up - executing command" 
+echo >&2 "Mysql is up - executing command"
 
 # Migrate the Django.
-python manage.py inspectdb > university/models.py
+python manage.py inspectdb >university/models.py
 python manage.py makemigrations
+python manage.py migrate --fake sessions zero
 python manage.py migrate university --fake
+python manage.py migrate --fake-initial
 
 # Initialize redis worker for celery and celery's beat scheduler in the background
 celery -A tasks worker --loglevel=INFO &
 celery -A tasks beat &
 
-# Initializes the API. 
+# Initializes the API.
 exec $cmd

--- a/django/entrypoint.sh
+++ b/django/entrypoint.sh
@@ -21,11 +21,11 @@ done
 echo >&2 "Mysql is up - executing command"
 
 # Migrate the Django.
-python manage.py inspectdb >university/models.py
 python manage.py makemigrations
 python manage.py migrate --fake sessions zero
 python manage.py migrate university --fake
 python manage.py migrate --fake-initial
+python manage.py inspectdb >university/models.py
 
 # Initialize redis worker for celery and celery's beat scheduler in the background
 celery -A tasks worker --loglevel=INFO &

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -9,3 +9,4 @@ mysqlclient==1.4.6
 celery==5.2.7
 redis==3.5.3
 requests==2.31.0
+djangorestframework-simplejwt==5.3.1

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -9,4 +9,5 @@ mysqlclient==1.4.6
 celery==5.2.7
 redis==3.5.3
 requests==2.31.0
-djangorestframework-simplejwt==5.3.1
+pyjwt==2.8.0
+python-dotenv==1.0.1

--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -35,7 +35,7 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    #'django.contrib.sessions', # legacy
+    'django.contrib.sessions', # legacy
     'django.contrib.messages',
     'rest_framework', 
     'django.contrib.staticfiles',
@@ -138,7 +138,6 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ]
-
 }
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -12,6 +12,12 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 from pathlib import Path
 import os 
+from dotenv import dotenv_values
+
+CONFIG={
+    **dotenv_values(".env"),  # load variables
+    **os.environ,  # override loaded values with environment variables
+}
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -23,7 +29,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-!d4s#a%mo7ou&nc+-b&qfx$nu&&vo_^z*kauh0-8@%)ni@ze+7'
 
-JWT_KEY= 'hello'
+JWT_KEY= CONFIG['JWT_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/django/tts_be/settings.py
+++ b/django/tts_be/settings.py
@@ -23,6 +23,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-!d4s#a%mo7ou&nc+-b&qfx$nu&&vo_^z*kauh0-8@%)ni@ze+7'
 
+JWT_KEY= 'hello'
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 ALLOWED_HOSTS = ['0.0.0.0', 'localhost']

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('statistics/', views.data),
     path('professors/<int:schedule>/', views.professor),
     path('info/', views.info),
-    path('login/', views.login)
+    path('login/', views.login),
+    path('submit_direct_exchange/', views.submit_direct_exchange)
 ]
 

--- a/django/university/urls.py
+++ b/django/university/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('professors/<int:schedule>/', views.professor),
     path('info/', views.info),
     path('login/', views.login),
-    path('submit_direct_exchange/', views.submit_direct_exchange)
+    path('submit_direct_exchange/', views.submit_direct_exchange),
+    path('verify_direct_exchange/<str:token>', views.verify_direct_exchange)
 ]
 

--- a/django/university/utils.py
+++ b/django/university/utils.py
@@ -1,0 +1,25 @@
+def get_student_schedule_url(username, semana_ini, semana_fim):
+    return f"https://sigarra.up.pt/feup/pt/mob_hor_geral.estudante?pv_codigo={username}&pv_semana_ini={semana_ini}&pv_semana_fim={semana_fim}" 
+
+def build_student_schedule_dict(schedule: list):
+    return {
+        (class_schedule["turma_sigla"], class_schedule["ucurr_sigla"]): class_schedule for class_schedule in schedule if class_schedule["tipo"] == "TP"
+    }
+
+def check_class_schedule_overlap(start_1: int, end_1: int, start_2: int, end_2: int) -> bool:
+    if (start_2 >= start_1 and start_2 <= end_1) or (start_1 >= start_2 and start_1 <= end_2):
+        return True
+
+    return False
+
+
+def exchange_overlap(student_schedules, student, class_to_insert) -> bool:
+    for class_schedule in student_schedules[student]:
+        if class_schedule["ucurr_sigla"] != class_to_insert["uccur_sigla"]:
+            (class_schedule_start, class_schedule_end) = (class_schedule["hora_inicio"], class_schedule["aula_duracao"] + class_schedule["hora_inicio"])
+            (overlap_param_start, overlap_param_end) = (class_to_insert["hora_inicio"], class_to_insert["aula_duracao"] + class_to_insert["hora_inicio"])
+
+            if check_class_schedule_overlap(class_schedule_start, class_schedule_end, overlap_param_start, overlap_param_end):
+                return True
+
+    return False

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -1,4 +1,5 @@
 from django.http.response import HttpResponse
+from django.contrib.auth import authenticate, login
 from university.models import Faculty
 from university.models import Course
 from university.models import CourseUnit
@@ -182,9 +183,16 @@ def login(request):
         if response.status_code == 200:
             for cookie in response.cookies:
                 new_response.set_cookie(cookie.name, cookie.value, httponly=True, secure=True)
-
+            
+            request.session["username"] = login_data["pv_login"]
             return new_response
         else:
             return new_response 
     except requests.exceptions.RequestException as e:
         return JsonResponse({"error": e}, safe=False)
+
+@api_view(["POST"])
+def submit_direct_exchange(request):
+    exchanges = request.POST.get('exchangeChoices')
+
+    return JsonResponse({"error": "Missing credentials"}, safe=False)

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -22,6 +22,7 @@ import requests
 import os 
 import jwt
 import json
+import datetime
 from django.utils import timezone
 # Create your views here. 
 
@@ -217,11 +218,11 @@ def submit_direct_exchange(request):
         return HttpResponse(status=curr_student_schedule.status_code)
 
     # TODO We need to change the fetched schedule with the exchange information we have in our database
+    # DirectExchangeParticipants.objects.filter(direct_exchange__accepted=True, participant=request.session["username"])
 
     student_schedules[request.session["username"]] = build_student_schedule_dict(json.loads(curr_student_schedule.content)["horario"])
 
     for curr_exchange in exchanges:
-        print(curr_exchange)
         curr_username = curr_exchange["other_student"]
         if not(curr_username in student_schedules):
             schedule_request = requests.get(get_student_schedule_url(curr_username, semana_ini, semana_fim), cookies=request.COOKIES)
@@ -270,15 +271,13 @@ def submit_direct_exchange(request):
             accepted=False
         ))
     
-    print("ie: ", inserted_exchanges)
     for inserted_exchange in inserted_exchanges:
         inserted_exchange.save()
 
     exchange.save()
     
     # 1. Create token
-    token = jwt.encode({"username": request.session["username"], "exchange_id": exchange.id}, JWT_KEY, algorithm="HS256")
-    print(token)
+    token = jwt.encode({"username": request.session["username"], "exchange_id": exchange.id, "exp": int(datetime.datetime.now() + datetime.timedelta(hours=2))}, JWT_KEY, algorithm="HS256")
     
     # 2. Send confirmation email
 

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -216,7 +216,8 @@ def submit_direct_exchange(request):
         inserted_exchange.save();
     
     # 1. Create token
-    token = jwt.encode({"username": request.session["username"], "exchange_id": "1"}, JWT_KEY, algorithm="HS256")
+    token = jwt.encode({"username": request.session["username"], "exchange_id": exchange.id}, JWT_KEY, algorithm="HS256")
+    print(token)
     
     # 2. Send confirmation email
 

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -1,6 +1,7 @@
 from django.http.response import HttpResponse
 from django.contrib.auth import authenticate, login
 from tts_be.settings import JWT_KEY
+from university.utils import get_student_schedule_url, build_student_schedule_dict, exchange_overlap
 from university.models import Faculty
 from university.models import Course
 from university.models import CourseUnit
@@ -199,21 +200,81 @@ def login(request):
 @api_view(["POST"])
 def submit_direct_exchange(request):
     exchanges = request.POST.getlist('exchangeChoices[]')
+    exchanges = list(map(lambda exchange : json.loads(exchange), exchanges))
 
-    exchange = DirectExchange(accepted=False)
-    exchange.save()
+    semana_ini = "20240101"
+    semana_fim = "20240601"
+
+    student_schedules = {}
+
+    curr_student_schedule = requests.get(get_student_schedule_url(
+        request.session["username"],
+        semana_ini,
+        semana_fim
+    ), cookies=request.COOKIES)
+
+    if(curr_student_schedule.status_code != 200):
+        return HttpResponse(status=curr_student_schedule.status_code)
+
+    # TODO We need to change the fetched schedule with the exchange information we have in our database
+
+    student_schedules[request.session["username"]] = build_student_schedule_dict(json.loads(curr_student_schedule.content)["horario"])
 
     for curr_exchange in exchanges:
-        curr_exchange = json.loads(curr_exchange)
-        inserted_exchange = DirectExchangeParticipants(
-            participant=request.session["username"],
-            old_class=curr_exchange["old_class"],
-            new_class=curr_exchange["new_class"],
+        print(curr_exchange)
+        curr_username = curr_exchange["other_student"]
+        if not(curr_username in student_schedules):
+            schedule_request = requests.get(get_student_schedule_url(curr_username, semana_ini, semana_fim), cookies=request.COOKIES)
+            if(schedule_request.status_code != 200):
+                return HttpResponse(status=curr_student_schedule.status_code)
+
+            schedule = json.loads(schedule_request.content)["horario"]
+            student_schedules[curr_username] = build_student_schedule_dict(schedule)
+    
+    exchange = DirectExchange(accepted=False)
+
+    inserted_exchanges = []
+    for curr_exchange in exchanges:
+        other_student = curr_exchange["other_student"]
+        course_unit = curr_exchange["course_unit"]
+        class_other_student_goes_to = curr_exchange["old_class"]
+        class_auth_student_goes_to = curr_exchange["new_class"]
+        
+        # If participant is neither enrolled in that course unit or in that class
+        other_student_valid = (class_auth_student_goes_to, course_unit) in student_schedules[other_student]
+        auth_user_valid = (class_other_student_goes_to, course_unit) in student_schedules[request.session["username"]]
+        if not(other_student_valid) or not(auth_user_valid):
+            return JsonResponse({"error": "students-with-incorrect-classes"}, status=400)
+
+        # Check of overlap
+        other_student_overlap_param = student_schedules[request.session["username"]][(class_other_student_goes_to, course_unit)]
+        auth_student_overlap_param = student_schedules[other_student][(class_auth_student_goes_to, course_unit)]
+
+        if exchange_overlap(student_schedules, auth_student_overlap_param) or exchange_overlap(student_schedules, other_student_overlap_param):
+            return JsonResponse({"error": "classes-overlap"}, status=400)
+        
+        # If no overlap, change it
+        student_schedules[request.session["username"]][(class_auth_student_goes_to, course_unit)] = student_schedules[other_student][(class_auth_student_goes_to, course_unit)]
+        student_schedules[other_student][(class_other_student_goes_to, course_unit)] = tmp
+
+        del student_schedules[other_student][(class_auth_student_goes_to, course_unit)] # remove old class of other student
+        del student_schedules[request.session["username"]][(class_other_student_goes_to, course_unit)] # remove old class of auth student
+        # If there are any, return http error
+
+        inserted_exchanges.append(DirectExchangeParticipants(
+            participant=curr_exchange["other_student"],
+            old_class=curr_exchange["new_class"], # This is not a typo, the old class of the authenticted student is the new class of the other student
+            new_class=curr_exchange["other_class"],
             course_unit=curr_exchange["course_unit"],
             direct_exchange=exchange,
             accepted=False
-        )
-        inserted_exchange.save();
+        ))
+    
+    print("ie: ", inserted_exchanges)
+    for inserted_exchange in inserted_exchanges:
+        inserted_exchange.save()
+
+    exchange.save()
     
     # 1. Create token
     token = jwt.encode({"username": request.session["username"], "exchange_id": exchange.id}, JWT_KEY, algorithm="HS256")

--- a/django/university/views.py
+++ b/django/university/views.py
@@ -255,6 +255,7 @@ def submit_direct_exchange(request):
             return JsonResponse({"error": "classes-overlap"}, status=400)
         
         # If no overlap, change it
+        tmp = student_schedules[request.session["username"]][(class_auth_student_goes_to, course_unit)]
         student_schedules[request.session["username"]][(class_auth_student_goes_to, course_unit)] = student_schedules[other_student][(class_auth_student_goes_to, course_unit)]
         student_schedules[other_student][(class_other_student_goes_to, course_unit)] = tmp
 

--- a/mysql/sql/00_schema_mysql.sql
+++ b/mysql/sql/00_schema_mysql.sql
@@ -141,19 +141,19 @@ CREATE TABLE `statistics` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE `direct_exchange` (
-  `id` INTEGER NOT NULL,
-  `accepted` boolean,
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
+  `accepted` boolean NOT NULL,
   PRIMARY KEY(`id`)
 ) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;
 
 CREATE TABLE `direct_exchange_participants` (
-  `id` INTEGER NOT NULL,
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
   `participant` varchar(32) NOT NULL,
   `old_class` varchar(16) NOT NULL,
   `new_class` varchar(16) NOT NULL,
   `course_unit` varchar(64) NOT NULL,
   `direct_exchange` INTEGER NOT NULL,
-  `accepted` boolean,
+  `accepted` boolean NOT NULL,
   PRIMARY KEY(`id`),
   FOREIGN KEY (`direct_exchange`) REFERENCES `direct_exchange`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;

--- a/mysql/sql/00_schema_mysql.sql
+++ b/mysql/sql/00_schema_mysql.sql
@@ -143,6 +143,7 @@ CREATE TABLE `statistics` (
 CREATE TABLE `direct_exchange` (
   `id` INTEGER NOT NULL AUTO_INCREMENT,
   `accepted` boolean NOT NULL,
+  `date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY(`id`)
 ) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;
 
@@ -154,6 +155,7 @@ CREATE TABLE `direct_exchange_participants` (
   `course_unit` varchar(64) NOT NULL,
   `direct_exchange` INTEGER NOT NULL,
   `accepted` boolean NOT NULL,
+  `date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY(`id`),
   FOREIGN KEY (`direct_exchange`) REFERENCES `direct_exchange`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;

--- a/mysql/sql/00_schema_mysql.sql
+++ b/mysql/sql/00_schema_mysql.sql
@@ -91,6 +91,10 @@ CREATE TABLE `schedule` (
   `composed_class_name` varchar(16) DEFAULT NULL
 ) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;
 
+
+
+-- alter TABLE course_metadata ADD FOREIGN KEY (`course_unit_id`) REFERENCES `course_unit`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
 -- -------------------------------------------------------- 
 
 --
@@ -136,6 +140,23 @@ CREATE TABLE `statistics` (
   `last_updated` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+CREATE TABLE `direct_exchange` (
+  `id` INTEGER NOT NULL,
+  `accepted` boolean,
+  PRIMARY KEY(`id`)
+) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;
+
+CREATE TABLE `direct_exchange_participants` (
+  `id` INTEGER NOT NULL,
+  `participant` varchar(32) NOT NULL,
+  `old_class` varchar(16) NOT NULL,
+  `new_class` varchar(16) NOT NULL,
+  `course_unit` varchar(64) NOT NULL,
+  `direct_exchange` INTEGER NOT NULL,
+  `accepted` boolean,
+  PRIMARY KEY(`id`),
+  FOREIGN KEY (`direct_exchange`) REFERENCES `direct_exchange`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB CHARSET = utf8 COLLATE = utf8_general_ci;
 
 -- Add primary keys 
 alter TABLE faculty ADD PRIMARY KEY (`acronym`);


### PR DESCRIPTION
Closes #4 

This is an initial implementation of the verification algorithm that checks if a direct exchange is valid or not.

The things that need to be implemented after are:

- Send an email with the token
- Consider already made direct exchanges that the users already made.
- Add rate limiting to verify exchange route

This is only being merged because there is infraestructure that will be needed by other features who would otherwise be blocked by this one.